### PR TITLE
Fix summary comments in filter apply extension

### DIFF
--- a/src/Filter/IQueryable.Apply.cs
+++ b/src/Filter/IQueryable.Apply.cs
@@ -7,7 +7,7 @@
 
     public static partial class IQueryableExtensions
     {
-        /// <summary>Applies order operations defined as <paramref name="particles"/>.</summary>
+        /// <summary>Applies the filter operations defined by <paramref name="particles"/>.</summary>
         /// <param name="source">The source.</param>
         /// <param name="particles">The particles.</param>
         /// <returns></returns>
@@ -40,7 +40,7 @@
     // Shortcut from IEnumerable<T>
     public static partial class IEnumerableExtensions
     {
-        /// <summary>Applies order operations defined as <paramref name="particles"/>.</summary>
+        /// <summary>Applies the filter operations defined by <paramref name="particles"/>.</summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="source">The source.</param>
         /// <param name="particles"><typeparamref name="T"/></param>


### PR DESCRIPTION
## Summary
- tweak the XML documentation for `IQueryable.Apply` to mention "filter operations" more clearly

## Testing
- `dotnet test` *(fails: NETSDK1045 - current SDK doesn't support target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685741170444833287d441c33570a84e