### PR TITLE
Fix regex for literal OR operator

### DIFF
--- a/src/Filter/Generators/ComplexLogicFilterParticleGrnerator.cs
+++ b/src/Filter/Generators/ComplexLogicFilterParticleGrnerator.cs
@@ -20,9 +20,9 @@
         {
             input = input.Trim();
 
-            // Attempt to split the input by all "||" not enclosed in quotes or parenthesis.
-            Regex regex = new Regex("[||](?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))(?=(((?!\\)).)*\\()|[^\\(\\)]*$)");
-            var splitInput = regex
+            // Attempt to split the input by all "||" not enclosed in quotes or parentheses.
+            Regex splitRegex = new Regex("\\|\\|(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))(?=(((?!\\)).)*\\()|[^\\(\\)]*$)");
+            var splitInput = splitRegex
                 .Split(input)
                 .Where(x => !string.IsNullOrWhiteSpace(x));
 

--- a/tests/Filter.Tests/Parsing/Generators/ComplexLogicGeneratorTests.cs
+++ b/tests/Filter.Tests/Parsing/Generators/ComplexLogicGeneratorTests.cs
@@ -1,0 +1,46 @@
+using Panner;
+using Panner.Builders;
+using Panner.Filter.Generators;
+using Panner.Filter.Particles;
+using Xunit;
+using Filter.Tests.Parsing.ByPropertyName;
+
+namespace Filter.Tests.Parsing.Generators
+{
+    public class ComplexLogicGeneratorTests
+    {
+        private static IPContext GetContext()
+        {
+            var builder = new PContextBuilder();
+            builder.Entity<FilterableOne>()
+                .Property(p => p.Filterable)
+                .IsFilterableByName();
+
+            return builder.Build();
+        }
+
+        [Fact]
+        public void DoublePipeParsesAsOr()
+        {
+            var context = GetContext();
+            var generator = new ComplexLogicGenerator<FilterableOne>();
+
+            var result = generator.TryGenerate(context, "Filterable=1||Filterable=2", out var particle);
+
+            Assert.True(result);
+            Assert.IsType<OrFilterParticle<FilterableOne>>(particle);
+        }
+
+        [Fact]
+        public void SinglePipeDoesNotParse()
+        {
+            var context = GetContext();
+            var generator = new ComplexLogicGenerator<FilterableOne>();
+
+            var result = generator.TryGenerate(context, "Filterable=1|Filterable=2", out var particle);
+
+            Assert.False(result);
+            Assert.Null(particle);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- escape literal `||` in the complex logic generator regex
- clarify comment and store regex in a named variable
- add regression tests for complex logic OR parsing

## Testing
- `dotnet test --framework net8.0 --no-restore --verbosity normal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68574119cb588332b73bbf480e299bfe