### PR TITLE
Improve test coverage

### DIFF
--- a/tests/Core.Tests/PContextTests.cs
+++ b/tests/Core.Tests/PContextTests.cs
@@ -1,0 +1,19 @@
+using System;
+using Panner;
+using Panner.Builders;
+using Xunit;
+
+namespace Core.Tests
+{
+    public class PContextTests
+    {
+        private class Sample { }
+
+        [Fact]
+        public void GetGeneratorsThrowsWhenEntityMissing()
+        {
+            var context = new PContextBuilder().Build();
+            Assert.Throws<Exception>(() => context.GetGenerators<Sample, ISortParticle<Sample>>());
+        }
+    }
+}

--- a/tests/Core.Tests/PEntityBuilderTests.cs
+++ b/tests/Core.Tests/PEntityBuilderTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Panner.Builders;
+using Xunit;
+
+namespace Core.Tests
+{
+    public class PEntityBuilderTests
+    {
+        private class WithField
+        {
+            public int Field;
+        }
+
+        private class Sample
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void PropertyExpressionWithMethodThrows()
+        {
+            var builder = new PContextBuilder().Entity<Sample>();
+            Assert.Throws<ArgumentException>(() => builder.Property(x => x.ToString()));
+        }
+
+        [Fact]
+        public void PropertyExpressionWithFieldThrows()
+        {
+            var builder = new PContextBuilder().Entity<WithField>();
+            Assert.Throws<ArgumentException>(() => builder.Property(x => x.Field));
+        }
+
+        [Fact]
+        public void PropertyExpressionFromDifferentTypeThrows()
+        {
+            var builder = new PContextBuilder().Entity<WithField>();
+            Assert.Throws<ArgumentException>(() => builder.Property(x => ((Sample)(object)x).Value));
+        }
+    }
+}

--- a/tests/Core.Tests/PEntityBuilderTests.cs
+++ b/tests/Core.Tests/PEntityBuilderTests.cs
@@ -8,7 +8,7 @@ namespace Core.Tests
     {
         private class WithField
         {
-            public int Field;
+            public int Field = 0;
         }
 
         private class Sample

--- a/tests/Filter.Tests/Particles/ParticleTests.cs
+++ b/tests/Filter.Tests/Particles/ParticleTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Panner.Filter.Particles;
+using Panner.Filter;
+using Xunit;
+
+namespace Filter.Tests.Particles
+{
+    public class ParticleTests
+    {
+        private class Fake
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void ByPropertyParticleEqual()
+        {
+            var prop = typeof(Fake).GetProperty(nameof(Fake.Value));
+            var particle = new ByPropertyParticle<Fake, int>(prop, Operator.Equal, 5);
+            var param = Expression.Parameter(typeof(Fake), "e");
+            var expr = particle.GetExpression(param);
+            var func = Expression.Lambda<Func<Fake, bool>>(expr, param).Compile();
+
+            Assert.True(func(new Fake { Value = 5 }));
+            Assert.False(func(new Fake { Value = 3 }));
+        }
+
+        [Fact]
+        public void AndFilterParticleCombinesExpressions()
+        {
+            var prop = typeof(Fake).GetProperty(nameof(Fake.Value));
+            var gt = new ByPropertyParticle<Fake, int>(prop, Operator.GreaterThan, 2);
+            var lt = new ByPropertyParticle<Fake, int>(prop, Operator.LessThan, 5);
+            var and = new AndFilterParticle<Fake>(gt, lt);
+            var param = Expression.Parameter(typeof(Fake), "e");
+            var expr = and.GetExpression(param);
+            var func = Expression.Lambda<Func<Fake, bool>>(expr, param).Compile();
+
+            Assert.True(func(new Fake { Value = 3 }));
+            Assert.False(func(new Fake { Value = 6 }));
+        }
+
+        [Fact]
+        public void OrFilterParticleCombinesExpressions()
+        {
+            var prop = typeof(Fake).GetProperty(nameof(Fake.Value));
+            var eq5 = new ByPropertyParticle<Fake, int>(prop, Operator.Equal, 5);
+            var eq7 = new ByPropertyParticle<Fake, int>(prop, Operator.Equal, 7);
+            var or = new OrFilterParticle<Fake>(eq5, eq7);
+            var param = Expression.Parameter(typeof(Fake), "e");
+            var expr = or.GetExpression(param);
+            var func = Expression.Lambda<Func<Fake, bool>>(expr, param).Compile();
+
+            Assert.True(func(new Fake { Value = 5 }));
+            Assert.True(func(new Fake { Value = 7 }));
+            Assert.False(func(new Fake { Value = 3 }));
+        }
+    }
+}

--- a/tests/Sort.Tests/Particles/ByPropertyParticleTests.cs
+++ b/tests/Sort.Tests/Particles/ByPropertyParticleTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using Panner.Sort.Particles;
+using Xunit;
+
+namespace Sort.Tests.Particles
+{
+    public class ByPropertyParticleTests
+    {
+        private class Fake
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void SortsAscending()
+        {
+            var prop = typeof(Fake).GetProperty(nameof(Fake.Value));
+            var particle = new ByPropertyParticle<Fake>(prop);
+            var data = new List<Fake>
+            {
+                new Fake{Value = 3},
+                new Fake{Value = 1},
+                new Fake{Value = 2},
+            }.AsQueryable().OrderBy(x => 0);
+
+            var result = particle.ApplyTo(data).Select(x => x.Value).ToList();
+            Assert.Equal(new List<int>{1,2,3}, result);
+        }
+
+        [Fact]
+        public void SortsDescending()
+        {
+            var prop = typeof(Fake).GetProperty(nameof(Fake.Value));
+            var particle = new ByPropertyParticle<Fake>(prop, true);
+            var data = new List<Fake>
+            {
+                new Fake{Value = 1},
+                new Fake{Value = 2},
+                new Fake{Value = 3},
+            }.AsQueryable().OrderBy(x => 0);
+
+            var result = particle.ApplyTo(data).Select(x => x.Value).ToList();
+            Assert.Equal(new List<int>{3,2,1}, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep `net9.0` as a target framework
- install a .NET 9 SDK for running tests

## Testing
- `dotnet test Panner.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857452a167c8332918fd655e3a6c7a6